### PR TITLE
Must use dry_run for semantic-release action

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -13,19 +13,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-      - name: Install semantic-release plugins
-        run: npm install @semantic-release/exec@^6.0.0
+        with:
+          fetch-depth: 0
       - name: Semantic release
         id: release
         uses: cycjimmy/semantic-release-action@v3
         with:
-          semantic_version: '^16.0.0'
-      - name: Release version ${{ steps.release.outputs.new_release_version }}
+          dry_run: true
+          semantic_version: '^19.0.0'
+      - name: Release version ${{ steps.release.outputs.new_release_version }} on ${{ github.ref_name }}
         uses: peter-evans/repository-dispatch@v2
         if: ${{ steps.release.outputs.new_release_published == 'true' }}
         with:
           token: ${{ secrets.GH_TOKEN }}
           event-type: version
-          client-payload: '{"version": "${{ steps.release.outputs.new_release_version }}"}'
+          client-payload: '{"version": "${{ steps.release.outputs.new_release_version }}", "branch": "${{ github.ref_name }}"}'


### PR DESCRIPTION
This was supposed to be in the original PR with this feature, but I did not bring in the fixed action from my test repo >_<