### PR TITLE
Use Ruby 3.0 in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="3"
+ARG VARIANT="3.0"
 
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "VARIANT": "3"
+      "VARIANT": "3.0"
     }
   },
   "extensions": [


### PR DESCRIPTION
This matches the version we develop and build on.