### PR TITLE
feat: expose request error fields

### DIFF
--- a/lib/seam/request.rb
+++ b/lib/seam/request.rb
@@ -7,6 +7,8 @@ module Seam
     attr_reader :base_uri, :api_key, :debug
 
     class Error < StandardError
+      attr_reader :status, :response
+
       def initialize(message, status, response)
         super(message)
         @status = status


### PR DESCRIPTION
Quick fix

Expose status and response fields for Request Error to allow easier handling. Error can now be handled like

```
begin
  # Invalid code length
  access_code = seamapi.access_codes.update(access_code_id: "access_code_id", code: "123") 
  puts access_code
rescue Seam::Request::Error => e
  # e.response.body is a string
  puts e.response.body

  # parse to json 
  body_json = JSON.parse(e.response.body)
  puts body_json["error"]
end
```