### PR TITLE
Adds missing connected_account_id to ConnectWebview

### DIFF
--- a/lib/seam/resources/connect_webview.rb
+++ b/lib/seam/resources/connect_webview.rb
@@ -2,7 +2,7 @@
 
 module Seam
   class ConnectWebview < BaseResource
-    attr_accessor :connect_webview_id, :custom_redirect_url, :custom_redirect_failure_url, :url,
+    attr_accessor :connect_webview_id, :connected_account_id, :custom_redirect_url, :custom_redirect_failure_url, :url,
       :workspace_id, :device_selection_mode, :accepted_providers, :selected_provider, :accepted_devices,
       :any_provider_allowed, :any_device_allowed, :login_successful, :status
 


### PR DESCRIPTION
The `connected_account_id` attribute is present in the JS SDK (https://github.com/seamapi/javascript/blob/66d46d569b45cacd8cdc84ec0632b17ac1f88256/src/types/models.ts#L250) but not in Ruby.

Trying it out in my own console we see the attribute not being set when initially creating the webview:
```
> view
 => 
<Seam::ConnectWebview:0x0017db80
  url="https://connect.getseam.com/connect_webviews/view?connect_webview_id=79973ed8-444b-4f49-8ae0-7a79f72b6402&auth_token=4jtHCBHvrh5P1J65vHtF1guwJ8CszTG3x"
  status="pending"
  created_at=2023-06-08 13:09:44.097872 +0000
  workspace_id="073c47ff-c6d8-4f81-ab10-eda14295fbe0"
  accepted_devices=[]
  login_successful=false
  accepted_providers=["august", "avigilon_alta", "schlage", "smartthings", "yale", "nuki", "salto", "controlbyweb", "minut", "my_2n", "kwikset", "ttlock", "noiseaware", "igloohome", "ecobee"]
  any_device_allowed=nil
  connect_webview_id="79973ed8-444b-4f49-8ae0-7a79f72b6402"
  custom_redirect_url=nil
  any_provider_allowed=false
  device_selection_mode="none"
  custom_redirect_failure_url=nil> 
```
```
> view.connected_account_id
 => nil 
```

And after authorizing it is there:
```
> seam.connect_webviews.get view.connect_webview_id
 => 
<Seam::ConnectWebview:0x0019f460                                                
  connect_webview_id="79973ed8-444b-4f49-8ae0-7a79f72b6402"                     
  url="https://connect.getseam.com/connect_webviews/view?connect_webview_id=79973ed8-444b-4f49-8ae0-7a79f72b6402&auth_token=4jtHCBHvrh5P1J65vHtF1guwJ8CszTG3x"  
  workspace_id="073c47ff-c6d8-4f81-ab10-eda14295fbe0"                           
  device_selection_mode="none"                                                  
  accepted_providers=["august", "avigilon_alta", "schlage", "smartthings", "yale", "nuki", "salto", "controlbyweb", "minut", "my_2n", "kwikset", "ttlock", "noiseaware", "igloohome", "ecobee"]                                                 
  selected_provider="august"                                                    
  accepted_devices=[]                                                           
  any_provider_allowed=false                                                    
  any_device_allowed=nil                                                        
  created_at=2023-06-08 13:09:44.097 UTC                                        
  login_successful=true
  status="authorized"
  connected_account_id="7bd80c2f-3ba2-4ac3-a2fe-02787ec08694">
```