### PR TITLE
Adds missing parameters for ConnectWebview creation

### DIFF
--- a/lib/seam/clients/connect_webviews.rb
+++ b/lib/seam/clients/connect_webviews.rb
@@ -23,13 +23,25 @@ module Seam
         )
       end
 
-      def create(accepted_providers: nil)
+      def create(
+        accepted_providers: nil,
+        custom_redirect_url: nil,
+        custom_redirect_failure_url: nil,
+        device_selection_mode: nil,
+        provider_category: nil
+      )
         request_seam_object(
           :post,
           "/connect_webviews/create",
           Seam::ConnectWebview,
           "connect_webview",
-          body: {accepted_providers: accepted_providers}
+          body: {
+            accepted_providers: accepted_providers,
+            custom_redirect_url: custom_redirect_url,
+            custom_redirect_failure_url: custom_redirect_failure_url,
+            device_selection_mode: device_selection_mode,
+            provider_category: provider_category
+          }.compact
         )
       end
     end

--- a/spec/clients/connect_webviews_spec.rb
+++ b/spec/clients/connect_webviews_spec.rb
@@ -41,17 +41,32 @@ RSpec.describe Seam::Clients::ConnectWebviews do
 
   describe "#create" do
     let(:accepted_providers) { %w[facebook google] }
+    let(:custom_redirect_url) { "http://localhost:3000/success" }
+    let(:custom_redirect_failure_url) { "http://localhost:3000/failure" }
+    let(:device_selection_mode) { "multiple" }
     let(:connect_webview_hash) { {connect_webview_id: "123"} }
 
     before do
       stub_seam_request(
         :post, "/connect_webviews/create", {connect_webview: connect_webview_hash}
       ).with do |req|
-        req.body.source == {accepted_providers: accepted_providers}.to_json
+        req.body.source == {
+          accepted_providers: accepted_providers,
+          custom_redirect_url: custom_redirect_url,
+          custom_redirect_failure_url: custom_redirect_failure_url,
+          device_selection_mode: device_selection_mode
+        }.to_json
       end
     end
 
-    let(:result) { client.connect_webviews.create(accepted_providers: accepted_providers) }
+    let(:result) do
+      client.connect_webviews.create(
+        accepted_providers: accepted_providers,
+        custom_redirect_url: custom_redirect_url,
+        custom_redirect_failure_url: custom_redirect_failure_url,
+        device_selection_mode: device_selection_mode
+      )
+    end
 
     it "returns a ConnectWebview" do
       expect(result).to be_a(Seam::ConnectWebview)


### PR DESCRIPTION
Adds missing parameters from the docs: https://docs.seam.co/latest/api-clients/connect-webviews/create-a-connect-webview#parameters

Might want to add to the Ruby SDK docs as well.

In action:
```
> seam.connect_webviews.create custom_redirect_url: 'http://localhost:3000/success', custom_redirect_failure_url: 'http://localhost:3000/failure', device_selection_mode: 'multiple'
 => 
<Seam::ConnectWebview:0x0039bc0
  url="https://connect.getseam.com/connect_webviews/view?connect_webview_id=d5b63064-1a31-4a92-b9f4-f0b0756d24d7&auth_token=8W1uRbJHhvmWb2VN6SQKz4rfeX7qSJVms"
  status="pending"             
  created_at=2023-06-09 01:26:40.146964 +0000
  workspace_id="073c47ff-c6d8-4f81-ab10-eda14295fbe0"
  accepted_devices=[]          
  login_successful=false       
  accepted_providers=["august", "avigilon_alta", "schlage", "smartthings", "yale", "nuki", "salto", "controlbyweb", "minut", "my_2n", "kwikset", "ttlock", "noiseaware", "igloohome", "ecobee"]
  any_device_allowed=nil       
  connect_webview_id="d5b63064-1a31-4a92-b9f4-f0b0756d24d7"
  custom_redirect_url="http://localhost:3000/success"
  any_provider_allowed=false
  device_selection_mode="multiple"
  custom_redirect_failure_url="http://localhost:3000/failure">
```