### PR TITLE
Fix update access code endpoint to be a PUT request

### DIFF
--- a/lib/seam/clients/access_codes.rb
+++ b/lib/seam/clients/access_codes.rb
@@ -52,7 +52,7 @@ module Seam
 
       def update(access_code_id: nil, name: nil, code: nil, starts_at: nil, ends_at: nil)
         action_attempt = request_seam_object(
-          :post,
+          :put,
           "/access_codes/update",
           Seam::ActionAttempt,
           "action_attempt",

--- a/lib/seam/clients/access_codes.rb
+++ b/lib/seam/clients/access_codes.rb
@@ -52,7 +52,7 @@ module Seam
 
       def update(access_code_id: nil, name: nil, code: nil, starts_at: nil, ends_at: nil)
         action_attempt = request_seam_object(
-          :put,
+          :patch,
           "/access_codes/update",
           Seam::ActionAttempt,
           "action_attempt",

--- a/spec/clients/access_codes_spec.rb
+++ b/spec/clients/access_codes_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Seam::Clients::AccessCodes do
 
     before do
       stub_seam_request(
-        :put,
+        :patch,
         "/access_codes/update",
         {
           action_attempt: {

--- a/spec/clients/access_codes_spec.rb
+++ b/spec/clients/access_codes_spec.rb
@@ -75,6 +75,31 @@ RSpec.describe Seam::Clients::AccessCodes do
     end
   end
 
+  describe "#update" do
+    let(:access_code_id) { "access_code_id_1234" }
+    let(:name) { "New access code name" }
+
+    before do
+      stub_seam_request(
+        :put,
+        "/access_codes/update",
+        {
+          action_attempt: {
+            status: "success"
+          }
+        }
+      ).with do |req|
+        req.body.source == {access_code_id: access_code_id, name: name}.to_json
+      end
+    end
+
+    let(:result) { client.access_codes.update(access_code_id: access_code_id, name: name) }
+
+    it "returns success" do
+      expect(result).to be_a(Seam::ActionAttempt)
+    end
+  end
+
   describe "#delete" do
     let(:access_code_id) { "access_code_1234" }
     let(:action_attempt_hash) { {action_attempt_id: "1234", status: "pending"} }


### PR DESCRIPTION
Hi,

I noticed that using the `update` in production I'm getting a 404 error. That is because in the gem it is coded as a POST instead of a PUT, this should fix it.

Thanks!