### PR TITLE
Adds automatically_manage_new_devices to ConnectWebview creation

### DIFF
--- a/lib/seam/clients/connect_webviews.rb
+++ b/lib/seam/clients/connect_webviews.rb
@@ -27,6 +27,7 @@ module Seam
         accepted_providers: nil,
         custom_redirect_url: nil,
         custom_redirect_failure_url: nil,
+        automatically_manage_new_devices: nil,
         device_selection_mode: nil,
         provider_category: nil
       )
@@ -39,6 +40,7 @@ module Seam
             accepted_providers: accepted_providers,
             custom_redirect_url: custom_redirect_url,
             custom_redirect_failure_url: custom_redirect_failure_url,
+            automatically_manage_new_devices: automatically_manage_new_devices,
             device_selection_mode: device_selection_mode,
             provider_category: provider_category
           }.compact

--- a/spec/clients/connect_webviews_spec.rb
+++ b/spec/clients/connect_webviews_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Seam::Clients::ConnectWebviews do
     let(:accepted_providers) { %w[facebook google] }
     let(:custom_redirect_url) { "http://localhost:3000/success" }
     let(:custom_redirect_failure_url) { "http://localhost:3000/failure" }
+    let(:automatically_manage_new_devices) { false }
     let(:device_selection_mode) { "multiple" }
     let(:connect_webview_hash) { {connect_webview_id: "123"} }
 
@@ -54,6 +55,7 @@ RSpec.describe Seam::Clients::ConnectWebviews do
           accepted_providers: accepted_providers,
           custom_redirect_url: custom_redirect_url,
           custom_redirect_failure_url: custom_redirect_failure_url,
+          automatically_manage_new_devices: automatically_manage_new_devices,
           device_selection_mode: device_selection_mode
         }.to_json
       end
@@ -64,6 +66,7 @@ RSpec.describe Seam::Clients::ConnectWebviews do
         accepted_providers: accepted_providers,
         custom_redirect_url: custom_redirect_url,
         custom_redirect_failure_url: custom_redirect_failure_url,
+        automatically_manage_new_devices: automatically_manage_new_devices,
         device_selection_mode: device_selection_mode
       )
     end


### PR DESCRIPTION
This flag was recently added to the JS SDK.

Not sure if it makes sense to keep adding the parameters here or if we should accept a generic `**params` hash and let the server provide error messages about invalid parameters?