### PR TITLE
Better error messages for all 4xx responses, e.g. HTTP 409

### DIFF
--- a/lib/seam/request.rb
+++ b/lib/seam/request.rb
@@ -44,7 +44,7 @@ module Seam
       msg = "Api Error #{response.status.code} #{method} #{uri}"
       code = response.status.code
 
-      if code == 400 && (err = response.parse["error"])
+      if code >= 400 && code < 500 && (err = response.parse["error"])
         msg = "Api Error #{err["type"]}\nrequest_id: #{err["request_id"]}\n#{err["message"]}"
       end
 

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -26,5 +26,28 @@ RSpec.describe Seam::Client do
         end
       end
     end
+
+    describe "409" do
+      let(:request_id) { "request_id_1234" }
+      let(:message) { "Some Error Message" }
+      let(:type) { "Some Error Type" }
+      let(:error) { {type: type, request_id: request_id, message: message} }
+
+      before do
+        stub_seam_request(
+          :get,
+          "/health",
+          {error: error},
+          status: 409
+        )
+      end
+
+      it "parses the error" do
+        expect { client.health }.to raise_error do |error|
+          expect(error).to be_a(Seam::Request::Error)
+          expect(error.message).to include(message).and include(type).and include(request_id)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Seam has a nice touch of exposing error response info for HTTP 400 errors - but not all 4xx errors. With this change we'll get the same benefits for e.g. HTTP 409 errors.

This now looks like this in my logs:
```
Seam::Request::Error: Api Error type: duplicate_access_code request_id: 6a08da7e-64f6-4709-97f7-c9a17b31ac21 Cannot set duplicate access code 1737 named HMRAHAM8ZA for period 2023-09-29T19:00:00.000Z-2...
```

Question: Do you know of any 4xx errors that might not work with this error handling? Should we only limit this to 400 and 409?