### PR TITLE
Add `unmanaged_devices.get` method, add `is_managed` and `capabilities_supported` props to unmanaged device object

### DIFF
--- a/lib/seam/clients/unmanaged_devices.rb
+++ b/lib/seam/clients/unmanaged_devices.rb
@@ -3,6 +3,19 @@
 module Seam
   module Clients
     class UnmanagedDevices < BaseClient
+      def get(device_id = nil, name: nil)
+        request_seam_object(
+          :get,
+          "/devices/unmanaged/get",
+          Seam::UnmanagedDevice,
+          "device",
+          params: {
+            device_id: device_id,
+            name: name
+          }.compact
+        )
+      end
+
       def list(params = {})
         request_seam_object(
           :get,

--- a/lib/seam/resources/unmanaged_device.rb
+++ b/lib/seam/resources/unmanaged_device.rb
@@ -2,7 +2,7 @@
 
 module Seam
   class UnmanagedDevice < BaseResource
-    attr_accessor :device_id, :device_type, :properties, :connected_account_id, :workspace_id
+    attr_accessor :device_id, :device_type, :properties, :connected_account_id, :workspace_id, :capabilities_supported, :is_managed
 
     date_accessor :created_at
 

--- a/spec/clients/unmanaged_devices_spec.rb
+++ b/spec/clients/unmanaged_devices_spec.rb
@@ -3,6 +3,46 @@
 RSpec.describe Seam::Clients::UnmanagedDevices do
   let(:client) { Seam::Client.new(api_key: "some_api_key") }
 
+  describe "#get" do
+    context "'device_id' param" do
+      let(:device_id) { "123" }
+      let(:device_hash) { {device_id: device_id} }
+
+      before do
+        stub_seam_request(
+          :get, "/devices/unmanaged/get", {device: device_hash}
+        ).with(
+          query: {device_id: device_id}
+        )
+      end
+
+      let(:result) { client.unmanaged_devices.get(device_id) }
+
+      it "returns an unmanaged Device" do
+        expect(result).to be_a(Seam::UnmanagedDevice)
+      end
+    end
+
+    context "'name' param" do
+      let(:name) { "name 123" }
+      let(:device_hash) { {name: name} }
+
+      before do
+        stub_seam_request(
+          :get, "/devices/unmanaged/get", {device: device_hash}
+        ).with(
+          query: {name: name}
+        )
+      end
+
+      let(:result) { client.unmanaged_devices.get(name: name) }
+
+      it "returns an unmanaged Device" do
+        expect(result).to be_a(Seam::UnmanagedDevice)
+      end
+    end
+  end
+
   describe "#list" do
     let(:device_hash) { {device_id: "123"} }
 


### PR DESCRIPTION
In relation to https://github.com/seamapi/ruby/issues/58