### PR TITLE
Add `access_code_ids` param to `access_codes.list` and `type` params to `access_codes.update`

### DIFF
--- a/lib/seam/clients/access_codes.rb
+++ b/lib/seam/clients/access_codes.rb
@@ -13,15 +13,15 @@ module Seam
         )
       end
 
-      def list(device_or_id)
+      def list(device_or_id = nil, access_code_ids: nil)
         device_id = device_or_id.is_a?(Seam::Device) ? device_or_id.device_id : device_or_id
 
         request_seam_object(
-          :get,
+          :post,
           "/access_codes/list",
           Seam::AccessCode,
           "access_codes",
-          params: {device_id: device_id}
+          body: {device_id: device_id, access_code_ids: access_code_ids}.compact
         )
       end
 

--- a/lib/seam/clients/access_codes.rb
+++ b/lib/seam/clients/access_codes.rb
@@ -50,7 +50,7 @@ module Seam
         action_attempt
       end
 
-      def update(access_code_id: nil, name: nil, code: nil, starts_at: nil, ends_at: nil)
+      def update(access_code_id: nil, name: nil, code: nil, starts_at: nil, ends_at: nil, type: nil)
         action_attempt = request_seam_object(
           :post,
           "/access_codes/update",
@@ -61,7 +61,8 @@ module Seam
             name: name,
             code: code,
             starts_at: starts_at,
-            ends_at: ends_at
+            ends_at: ends_at,
+            type: type
           }.compact
         )
         action_attempt.wait_until_finished

--- a/spec/clients/access_codes_spec.rb
+++ b/spec/clients/access_codes_spec.rb
@@ -126,4 +126,33 @@ RSpec.describe Seam::Clients::AccessCodes do
       expect(result).to be_a(Seam::ActionAttempt)
     end
   end
+
+  describe "#update" do
+    let(:access_code_id) { "access_code_1234" }
+    let(:action_attempt_hash) { {action_attempt_id: "1234", status: "pending"} }
+
+    before do
+      stub_seam_request(
+        :post, "/access_codes/update", {action_attempt: action_attempt_hash}
+      ).with do |req|
+        req.body.source == {access_code_id: access_code_id, type: "ongoing"}.to_json
+      end
+
+      stub_seam_request(
+        :get,
+        "/action_attempts/get",
+        {
+          action_attempt: {
+            status: "success"
+          }
+        }
+      ).with(query: {action_attempt_id: action_attempt_hash[:action_attempt_id]})
+    end
+
+    let(:result) { client.access_codes.update(access_code_id: access_code_id, type: "ongoing") }
+
+    it "returns an Access Code" do
+      expect(result).to be_a(Seam::ActionAttempt)
+    end
+  end
 end

--- a/spec/clients/access_codes_spec.rb
+++ b/spec/clients/access_codes_spec.rb
@@ -4,20 +4,43 @@ RSpec.describe Seam::Clients::AccessCodes do
   let(:client) { Seam::Client.new(api_key: "some_api_key") }
 
   describe "#list" do
-    let(:access_code_hash) { {access_code_id: "123"} }
-    let(:device_id) { "device_id_1234" }
+    let(:access_code_id) { "123" }
+    let(:access_code_hash) { {access_code_id: access_code_id} }
 
-    before do
-      stub_seam_request(:get, "/access_codes/list",
-        {access_codes: [access_code_hash]}).with(query: {device_id: device_id})
+    context "'device_id' param" do
+      let(:device_id) { "device_id_1234" }
+
+      before do
+        stub_seam_request(:post, "/access_codes/list",
+          {access_codes: [access_code_hash]}).with do |req|
+          req.body.source == {device_id: device_id}.to_json
+        end
+      end
+
+      let(:access_codes) { client.access_codes.list(device_id) }
+
+      it "returns a list of Access codes" do
+        expect(access_codes).to be_a(Array)
+        expect(access_codes.first).to be_a(Seam::AccessCode)
+        expect(access_codes.first.access_code_id).to be_a(String)
+      end
     end
 
-    let(:access_codes) { client.access_codes.list(device_id) }
+    context "'access_code_ids' param" do
+      before do
+        stub_seam_request(:post, "/access_codes/list",
+          {access_codes: [access_code_hash]}).with do |req|
+            req.body.source == {access_code_ids: [access_code_id]}.to_json
+          end
+      end
 
-    it "returns a list of Devices" do
-      expect(access_codes).to be_a(Array)
-      expect(access_codes.first).to be_a(Seam::AccessCode)
-      expect(access_codes.first.access_code_id).to be_a(String)
+      let(:access_codes) { client.access_codes.list(access_code_ids: [access_code_id]) }
+
+      it "returns a list of Access codes" do
+        expect(access_codes).to be_a(Array)
+        expect(access_codes.first).to be_a(Seam::AccessCode)
+        expect(access_codes.first.access_code_id).to be_a(String)
+      end
     end
   end
 


### PR DESCRIPTION
In relation to https://github.com/seamapi/ruby/issues/58