### PR TITLE
feat: Always use POST to normalize request serialization

### DIFF
--- a/lib/seam/clients/access_codes.rb
+++ b/lib/seam/clients/access_codes.rb
@@ -5,11 +5,11 @@ module Seam
     class AccessCodes < BaseClient
       def get(access_code_id)
         request_seam_object(
-          :get,
+          :post,
           "/access_codes/get",
           Seam::AccessCode,
           "access_code",
-          params: {access_code_id: access_code_id}
+          body: {access_code_id: access_code_id}
         )
       end
 

--- a/lib/seam/clients/action_attempts.rb
+++ b/lib/seam/clients/action_attempts.rb
@@ -5,11 +5,11 @@ module Seam
     class ActionAttempts < BaseClient
       def get(action_attempt_id)
         request_seam_object(
-          :get,
+          :post,
           "/action_attempts/get",
           Seam::ActionAttempt,
           "action_attempt",
-          params: {action_attempt_id: action_attempt_id}
+          body: {action_attempt_id: action_attempt_id}
         )
       end
     end

--- a/lib/seam/clients/connect_webviews.rb
+++ b/lib/seam/clients/connect_webviews.rb
@@ -5,21 +5,21 @@ module Seam
     class ConnectWebviews < BaseClient
       def get(connect_webview_id = nil)
         request_seam_object(
-          :get,
+          :post,
           "/connect_webviews/get",
           Seam::ConnectWebview,
           "connect_webview",
-          params: {connect_webview_id: connect_webview_id}
+          body: {connect_webview_id: connect_webview_id}
         )
       end
 
       def list
         request_seam_object(
-          :get,
+          :post,
           "/connect_webviews/list",
           Seam::ConnectWebview,
           "connect_webviews",
-          params: {}
+          body: {}
         )
       end
 

--- a/lib/seam/clients/connected_accounts.rb
+++ b/lib/seam/clients/connected_accounts.rb
@@ -3,29 +3,29 @@
 module Seam
   module Clients
     class ConnectedAccounts < BaseClient
-      def get(connected_account_id_or_params)
-        params = if connected_account_id_or_params.is_a?(String)
-          {connected_account_id: connected_account_id_or_params}
+      def get(connected_account_id_or_body)
+        body = if connected_account_id_or_body.is_a?(String)
+          {connected_account_id: connected_account_id_or_body}
         else
-          connected_account_id_or_params
+          connected_account_id_or_body
         end
 
         request_seam_object(
-          :get,
+          :post,
           "/connected_accounts/get",
           Seam::ConnectedAccount,
           "connected_account",
-          params: params
+          body: body
         )
       end
 
-      def list(params = {})
+      def list(body = {})
         request_seam_object(
-          :get,
+          :post,
           "/connected_accounts/list",
           Seam::ConnectedAccount,
           "connected_accounts",
-          params: params
+          body: body
         )
       end
     end

--- a/lib/seam/clients/devices.rb
+++ b/lib/seam/clients/devices.rb
@@ -3,29 +3,29 @@
 module Seam
   module Clients
     class Devices < BaseClient
-      def list(params = {})
+      def list(body = {})
         request_seam_object(
-          :get,
+          :post,
           "/devices/list",
           Seam::Device,
           "devices",
-          params: params
+          body: body
         )
       end
 
       def get(device_id = nil, name: nil)
         request_seam_object(
-          :get,
+          :post,
           "/devices/get",
           Seam::Device,
           "device",
-          params: {device_id: device_id, name: name}.compact
+          body: {device_id: device_id, name: name}.compact
         )
       end
 
       def update(device_id: nil, is_managed: nil, name: nil, properties: nil)
         request_seam(
-          :patch,
+          :post,
           "/devices/update",
           body: {
             device_id: device_id,
@@ -36,13 +36,13 @@ module Seam
         )
       end
 
-      def list_device_providers(params = {})
+      def list_device_providers(body = {})
         request_seam_object(
-          :get,
+          :post,
           "/devices/list_device_providers",
           Seam::DeviceProvider,
           "device_providers",
-          params: params
+          body: body
         )
       end
     end

--- a/lib/seam/clients/events.rb
+++ b/lib/seam/clients/events.rb
@@ -5,22 +5,22 @@ module Seam
     class Events < BaseClient
       def get(event_id: nil, event_type: nil, device_id: nil)
         request_seam_object(
-          :get,
+          :post,
           "/events/get",
           Seam::Event,
           "event",
-          params: {event_id: event_id, event_type: event_type, device_id: device_id}.compact
+          body: {event_id: event_id, event_type: event_type, device_id: device_id}.compact
         )
       end
 
       def list(since: str, event_type: nil, event_types: nil, device_id: nil, device_ids: nil)
         request_seam_object(
-          :get,
+          :post,
           "/events/list",
           Seam::Event,
           "events",
-          params: {event_type: event_type, event_types: event_types, device_id: device_id,
-                   device_ids: device_ids, since: since}.compact
+          body: {event_type: event_type, event_types: event_types, device_id: device_id,
+                 device_ids: device_ids, since: since}.compact
         )
       end
     end

--- a/lib/seam/clients/locks.rb
+++ b/lib/seam/clients/locks.rb
@@ -35,23 +35,23 @@ module Seam
         )
       end
 
-      def list(params = {})
+      def list(body = {})
         request_seam_object(
-          :get,
+          :post,
           "/locks/list",
           Seam::Device,
           "locks",
-          params: params
+          body: body
         )
       end
 
       def get(device_or_id)
         request_seam_object(
-          :get,
+          :post,
           "/locks/get",
           Seam::Device,
           "lock",
-          params: {
+          body: {
             device_id: device_id(device_or_id)
           }
         )

--- a/lib/seam/clients/unmanaged_access_codes.rb
+++ b/lib/seam/clients/unmanaged_access_codes.rb
@@ -5,11 +5,11 @@ module Seam
     class UnmanagedAccessCodes < BaseClient
       def get(access_code_id = nil, device_id: nil, code: nil)
         request_seam_object(
-          :get,
+          :post,
           "/access_codes/unmanaged/get",
           Seam::UnmanagedAccessCode,
           "access_code",
-          params: {
+          body: {
             device_id: device_id,
             access_code_id: access_code_id,
             code: code
@@ -19,11 +19,11 @@ module Seam
 
       def list(device_id)
         request_seam_object(
-          :get,
+          :post,
           "/access_codes/unmanaged/list",
           Seam::UnmanagedAccessCode,
           "access_codes",
-          params: {device_id: device_id}
+          body: {device_id: device_id}
         )
       end
 

--- a/lib/seam/clients/unmanaged_devices.rb
+++ b/lib/seam/clients/unmanaged_devices.rb
@@ -5,30 +5,30 @@ module Seam
     class UnmanagedDevices < BaseClient
       def get(device_id = nil, name: nil)
         request_seam_object(
-          :get,
+          :post,
           "/devices/unmanaged/get",
           Seam::UnmanagedDevice,
           "device",
-          params: {
+          body: {
             device_id: device_id,
             name: name
           }.compact
         )
       end
 
-      def list(params = {})
+      def list(body = {})
         request_seam_object(
-          :get,
+          :post,
           "/devices/unmanaged/list",
           Seam::UnmanagedDevice,
           "devices",
-          params: params
+          body: body
         )
       end
 
       def update(device_id: nil, is_managed: nil)
         request_seam(
-          :patch,
+          :post,
           "/devices/unmanaged/update",
           body: {
             device_id: device_id,

--- a/lib/seam/clients/workspaces.rb
+++ b/lib/seam/clients/workspaces.rb
@@ -5,21 +5,21 @@ module Seam
     class Workspaces < BaseClient
       def get(workspace_id = nil)
         request_seam_object(
-          :get,
+          :post,
           "/workspaces/get",
           Seam::Workspace,
           "workspace",
-          params: {workspace_id: workspace_id}
+          body: {workspace_id: workspace_id}
         )
       end
 
       def list
         request_seam_object(
-          :get,
+          :post,
           "/workspaces/list",
           Seam::Workspace,
           "workspaces",
-          params: {}
+          body: {}
         )
       end
 
@@ -27,7 +27,7 @@ module Seam
         request_seam(
           :post,
           "/workspaces/reset_sandbox",
-          params: {workspace_id: workspace_id}
+          body: {workspace_id: workspace_id}
         )
       end
     end

--- a/lib/seam/resources/action_attempt.rb
+++ b/lib/seam/resources/action_attempt.rb
@@ -19,9 +19,9 @@ module Seam
 
     def update!
       response = @client.request_seam(
-        :get,
+        :post,
         "/action_attempts/get",
-        params: {
+        body: {
           action_attempt_id: action_attempt_id
         }
       )

--- a/spec/clients/access_codes_spec.rb
+++ b/spec/clients/access_codes_spec.rb
@@ -52,13 +52,11 @@ RSpec.describe Seam::Clients::AccessCodes do
 
     before do
       stub_seam_request(
-        :get, "/access_codes/get", {access_code: access_code_hash.merge(
+        :post, "/access_codes/get", {access_code: access_code_hash.merge(
           errors: [failed_to_set_error],
           warnings: [delay_in_setting_warning]
         )}
-      ).with(
-        query: {access_code_id: access_code_id}
-      )
+      ).with { |req| req.body.source == {access_code_id: access_code_id}.to_json }
     end
 
     let(:result) { client.access_codes.get(access_code_id) }
@@ -86,9 +84,9 @@ RSpec.describe Seam::Clients::AccessCodes do
       )
 
       stub_seam_request(
-        :get, "/action_attempts/get", {action_attempt: {result: {access_code: access_code_hash},
-                                                        status: "success"}}
-      ).with(query: {action_attempt_id: action_attempt_hash[:action_attempt_id]})
+        :post, "/action_attempts/get", {action_attempt: {result: {access_code: access_code_hash},
+                                                         status: "success"}}
+      ).with { |req| req.body.source == {action_attempt_id: action_attempt_hash[:action_attempt_id]}.to_json }
     end
 
     let(:result) { client.access_codes.create(**access_code_hash) }
@@ -110,14 +108,14 @@ RSpec.describe Seam::Clients::AccessCodes do
       end
 
       stub_seam_request(
-        :get,
+        :post,
         "/action_attempts/get",
         {
           action_attempt: {
             status: "success"
           }
         }
-      ).with(query: {action_attempt_id: action_attempt_hash[:action_attempt_id]})
+      ).with { |req| req.body.source == {action_attempt_id: action_attempt_hash[:action_attempt_id]}.to_json }
     end
 
     let(:result) { client.access_codes.delete(access_code_id) }
@@ -139,14 +137,14 @@ RSpec.describe Seam::Clients::AccessCodes do
       end
 
       stub_seam_request(
-        :get,
+        :post,
         "/action_attempts/get",
         {
           action_attempt: {
             status: "success"
           }
         }
-      ).with(query: {action_attempt_id: action_attempt_hash[:action_attempt_id]})
+      ).with { |req| req.body.source == {action_attempt_id: action_attempt_hash[:action_attempt_id]}.to_json }
     end
 
     let(:result) { client.access_codes.update(access_code_id: access_code_id, type: "ongoing") }

--- a/spec/clients/action_attempts_spec.rb
+++ b/spec/clients/action_attempts_spec.rb
@@ -9,10 +9,8 @@ RSpec.describe Seam::Clients::AccessCodes do
 
     before do
       stub_seam_request(
-        :get, "/action_attempts/get", {action_attempt: action_attempt_hash}
-      ).with(
-        query: {action_attempt_id: action_attempt_id}
-      )
+        :post, "/action_attempts/get", {action_attempt: action_attempt_hash}
+      ).with { |req| req.body.source == {action_attempt_id: action_attempt_id}.to_json }
     end
 
     let(:result) { client.action_attempts.get(action_attempt_id) }

--- a/spec/clients/connect_webviews_spec.rb
+++ b/spec/clients/connect_webviews_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Seam::Clients::ConnectWebviews do
     # let(:device_id) { "device_id_1234" }
 
     before do
-      stub_seam_request(:get, "/connect_webviews/list", {connect_webviews: [connect_webview_hash]})
+      stub_seam_request(:post, "/connect_webviews/list", {connect_webviews: [connect_webview_hash]})
     end
 
     let(:connect_webviews) { client.connect_webviews.list }
@@ -26,10 +26,8 @@ RSpec.describe Seam::Clients::ConnectWebviews do
 
     before do
       stub_seam_request(
-        :get, "/connect_webviews/get", {connect_webview: connect_webview_hash}
-      ).with(
-        query: {connect_webview_id: connect_webview_id}
-      )
+        :post, "/connect_webviews/get", {connect_webview: connect_webview_hash}
+      ).with { |req| req.body.source == {connect_webview_id: connect_webview_id}.to_json }
     end
 
     let(:result) { client.connect_webviews.get(connect_webview_id) }

--- a/spec/clients/connected_accounts_spec.rb
+++ b/spec/clients/connected_accounts_spec.rb
@@ -10,10 +10,8 @@ RSpec.describe Seam::Clients::ConnectedAccounts do
     context "with connected_account_id" do
       before do
         stub_seam_request(
-          :get, "/connected_accounts/get", {connected_account: connected_account_hash}
-        ).with(
-          query: {connected_account_id: connected_account_id}
-        )
+          :post, "/connected_accounts/get", {connected_account: connected_account_hash}
+        ).with { |req| req.body.source == {connected_account_id: connected_account_id}.to_json }
       end
 
       let(:result) { client.connected_accounts.get(connected_account_id) }
@@ -28,10 +26,8 @@ RSpec.describe Seam::Clients::ConnectedAccounts do
 
       before do
         stub_seam_request(
-          :get, "/connected_accounts/get", {connected_account: connected_account_hash}
-        ).with(
-          query: {email: email}
-        )
+          :post, "/connected_accounts/get", {connected_account: connected_account_hash}
+        ).with { |req| req.body.source == {email: email}.to_json }
       end
 
       let(:result) { client.connected_accounts.get(email: email) }
@@ -47,13 +43,11 @@ RSpec.describe Seam::Clients::ConnectedAccounts do
 
       before do
         stub_seam_request(
-          :get, "/connected_accounts/get", {connected_account: connected_account_hash.merge(
+          :post, "/connected_accounts/get", {connected_account: connected_account_hash.merge(
             errors: [account_disconnected_error],
             warnings: [limit_reached_warning]
           )}
-        ).with(
-          query: {connected_account_id: connected_account_id}
-        )
+        ).with { |req| req.body.source == {connected_account_id: connected_account_id}.to_json }
       end
 
       let(:result) { client.connected_accounts.get(connected_account_id) }
@@ -73,7 +67,7 @@ RSpec.describe Seam::Clients::ConnectedAccounts do
 
     before do
       stub_seam_request(
-        :get, "/connected_accounts/list", {connected_accounts: [connected_account_hash]}
+        :post, "/connected_accounts/list", {connected_accounts: [connected_account_hash]}
       )
     end
 

--- a/spec/clients/devices_spec.rb
+++ b/spec/clients/devices_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Seam::Clients::Devices do
     let(:device_hash) { {device_id: "123"} }
 
     before do
-      stub_seam_request(:get, "/devices/list", {devices: [device_hash]})
+      stub_seam_request(:post, "/devices/list", {devices: [device_hash]})
     end
 
     let(:devices) { client.devices.list }
@@ -25,7 +25,7 @@ RSpec.describe Seam::Clients::Devices do
       let(:device_hash) { {device_id: device_id} }
 
       before do
-        stub_seam_request(:get, "/devices/get", {device: device_hash}).with(query: {device_id: device_id})
+        stub_seam_request(:post, "/devices/get", {device: device_hash}).with { |req| req.body.source == {device_id: device_id}.to_json }
       end
 
       let(:result) { client.devices.get(device_id) }
@@ -40,7 +40,7 @@ RSpec.describe Seam::Clients::Devices do
       let(:device_hash) { {name: name} }
 
       before do
-        stub_seam_request(:get, "/devices/get", {device: device_hash}).with(query: {name: name})
+        stub_seam_request(:post, "/devices/get", {device: device_hash}).with { |req| req.body.source == {name: name}.to_json }
       end
 
       let(:result) { client.devices.get(name: name) }
@@ -58,12 +58,12 @@ RSpec.describe Seam::Clients::Devices do
     let(:device_privacy_warning) { {warning_code: "privacy_mode", message: "Device is in privacy mode"} }
 
     before do
-      stub_seam_request(:get, "/devices/get", {
+      stub_seam_request(:post, "/devices/get", {
         device: device_hash.merge(
           errors: [device_removed_error],
           warnings: [device_privacy_warning]
         )
-      }).with(query: {device_id: device_id})
+      }).with { |req| req.body.source == {device_id: device_id}.to_json }
     end
 
     let(:result) { client.devices.get(device_id) }
@@ -98,7 +98,7 @@ RSpec.describe Seam::Clients::Devices do
 
   describe "#list_device_providers" do
     before do
-      stub_seam_request(:get, "/devices/list_device_providers",
+      stub_seam_request(:post, "/devices/list_device_providers",
         {device_providers: [device_provider_hash, stable_device_provider_hash]})
     end
 
@@ -116,9 +116,9 @@ RSpec.describe Seam::Clients::Devices do
 
   describe "#list_device_providers (provider_category=stable)" do
     before do
-      stub_seam_request(:get, "/devices/list_device_providers",
+      stub_seam_request(:post, "/devices/list_device_providers",
         {device_providers: [stable_device_provider_hash]})
-        .with(query: {provider_category: "stable"})
+        .with { |req| req.body.source == {provider_category: "stable"}.to_json }
     end
 
     let(:device_providers) { client.devices.list_device_providers({provider_category: "stable"}) }
@@ -139,7 +139,7 @@ RSpec.describe Seam::Clients::Devices do
     let(:name) { "New Device Name" }
 
     before do
-      stub_seam_request(:patch, "/devices/update", {ok: true})
+      stub_seam_request(:post, "/devices/update", {ok: true})
         .with do |req|
           req.body.source == {device_id: device_id, name: name}.to_json
         end

--- a/spec/clients/events_spec.rb
+++ b/spec/clients/events_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Seam::Clients::Events do
     let(:event_hash) { {event_id: "1234"} }
 
     before do
-      stub_seam_request(:get, "/events/list", {events: [event_hash]}).with(query: {since: "asd"})
+      stub_seam_request(:post, "/events/list", {events: [event_hash]}).with { |req| req.body.source == {since: "asd"}.to_json }
     end
 
     let(:events) { client.events.list(since: "asd") }
@@ -24,7 +24,7 @@ RSpec.describe Seam::Clients::Events do
     let(:event_hash) { {event_id: event_id} }
 
     before do
-      stub_seam_request(:get, "/events/get", {event: event_hash}).with(query: {event_id: event_id})
+      stub_seam_request(:post, "/events/get", {event: event_hash}).with { |req| req.body.source == {event_id: event_id}.to_json }
     end
 
     let(:result) { client.events.get(event_id: event_id) }

--- a/spec/clients/locks_spec.rb
+++ b/spec/clients/locks_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Seam::Clients::Locks do
     let(:locks_hash) { {device_id: "123"} }
 
     before do
-      stub_seam_request(:get, "/locks/list", {locks: [locks_hash]})
+      stub_seam_request(:post, "/locks/list", {locks: [locks_hash]})
     end
 
     let(:devices) { client.locks.list }
@@ -24,7 +24,7 @@ RSpec.describe Seam::Clients::Locks do
     let(:locks_hash) { {device_id: device_id} }
 
     before do
-      stub_seam_request(:get, "/locks/get", {lock: locks_hash}).with(query: {device_id: device_id})
+      stub_seam_request(:post, "/locks/get", {lock: locks_hash}).with { |req| req.body.source == {device_id: device_id}.to_json }
     end
 
     let(:lock) { client.locks.get(device_id) }

--- a/spec/clients/unmanaged_access_codes_spec.rb
+++ b/spec/clients/unmanaged_access_codes_spec.rb
@@ -9,10 +9,8 @@ RSpec.describe Seam::Clients::UnmanagedAccessCodes do
 
     before do
       stub_seam_request(
-        :get, "/access_codes/unmanaged/get", {access_code: unmanaged_access_code_hash}
-      ).with(
-        query: {access_code_id: access_code_id}
-      )
+        :post, "/access_codes/unmanaged/get", {access_code: unmanaged_access_code_hash}
+      ).with { |req| req.body.source == {access_code_id: access_code_id}.to_json }
     end
 
     let(:result) { client.unmanaged_access_codes.get(access_code_id) }
@@ -27,9 +25,7 @@ RSpec.describe Seam::Clients::UnmanagedAccessCodes do
     let(:unmanaged_access_code_hash) { {access_code_id: "123", device_id: device_id} }
 
     before do
-      stub_seam_request(:get, "/access_codes/unmanaged/list", {access_codes: [unmanaged_access_code_hash]}).with(
-        query: {device_id: device_id}
-      )
+      stub_seam_request(:post, "/access_codes/unmanaged/list", {access_codes: [unmanaged_access_code_hash]}).with { |req| req.body.source == {device_id: device_id}.to_json }
     end
 
     let(:unmanaged_access_codes) { client.unmanaged_access_codes.list(device_id) }
@@ -53,14 +49,14 @@ RSpec.describe Seam::Clients::UnmanagedAccessCodes do
       end
 
       stub_seam_request(
-        :get,
+        :post,
         "/action_attempts/get",
         {
           action_attempt: {
             status: "success"
           }
         }
-      ).with(query: {action_attempt_id: action_attempt_hash[:action_attempt_id]})
+      ).with { |req| req.body.source == {action_attempt_id: action_attempt_hash[:action_attempt_id]}.to_json }
     end
 
     let(:result) { client.unmanaged_access_codes.convert_to_managed(access_code_id) }

--- a/spec/clients/unmanaged_devices_spec.rb
+++ b/spec/clients/unmanaged_devices_spec.rb
@@ -10,10 +10,8 @@ RSpec.describe Seam::Clients::UnmanagedDevices do
 
       before do
         stub_seam_request(
-          :get, "/devices/unmanaged/get", {device: device_hash}
-        ).with(
-          query: {device_id: device_id}
-        )
+          :post, "/devices/unmanaged/get", {device: device_hash}
+        ).with { |req| req.body.source == {device_id: device_id}.to_json }
       end
 
       let(:result) { client.unmanaged_devices.get(device_id) }
@@ -29,10 +27,8 @@ RSpec.describe Seam::Clients::UnmanagedDevices do
 
       before do
         stub_seam_request(
-          :get, "/devices/unmanaged/get", {device: device_hash}
-        ).with(
-          query: {name: name}
-        )
+          :post, "/devices/unmanaged/get", {device: device_hash}
+        ).with { |req| req.body.source == {name: name}.to_json }
       end
 
       let(:result) { client.unmanaged_devices.get(name: name) }
@@ -47,7 +43,7 @@ RSpec.describe Seam::Clients::UnmanagedDevices do
     let(:device_hash) { {device_id: "123"} }
 
     before do
-      stub_seam_request(:get, "/devices/unmanaged/list", {devices: [device_hash]})
+      stub_seam_request(:post, "/devices/unmanaged/list", {devices: [device_hash]})
     end
 
     let(:unmanaged_devices) { client.unmanaged_devices.list }
@@ -64,7 +60,7 @@ RSpec.describe Seam::Clients::UnmanagedDevices do
     let(:is_managed) { true }
 
     before do
-      stub_seam_request(:patch, "/devices/unmanaged/update", {ok: true})
+      stub_seam_request(:post, "/devices/unmanaged/update", {ok: true})
         .with do |req|
           req.body.source == {device_id: device_id, is_managed: is_managed}.to_json
         end

--- a/spec/clients/workspaces_spec.rb
+++ b/spec/clients/workspaces_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Seam::Clients::Workspaces do
     let(:workspace_hash) { {workspace_id: "123"} }
 
     before do
-      stub_seam_request(:get, "/workspaces/list", {workspaces: [workspace_hash]})
+      stub_seam_request(:post, "/workspaces/list", {workspaces: [workspace_hash]})
     end
 
     let(:workspaces) { client.workspaces.list }
@@ -25,10 +25,8 @@ RSpec.describe Seam::Clients::Workspaces do
 
     before do
       stub_seam_request(
-        :get, "/workspaces/get", {workspace: workspace_hash}
-      ).with(
-        query: {workspace_id: workspace_id}
-      )
+        :post, "/workspaces/get", {workspace: workspace_hash}
+      ).with { |req| req.body.source == {workspace_id: workspace_id}.to_json }
     end
 
     let(:result) { client.workspaces.get(workspace_id) }
@@ -44,9 +42,7 @@ RSpec.describe Seam::Clients::Workspaces do
     before do
       stub_seam_request(
         :post, "/workspaces/reset_sandbox", {message: "ok"}
-      ).with(
-        query: {workspace_id: workspace_id}
-      )
+      ).with { |req| req.body.source == {workspace_id: workspace_id}.to_json }
     end
 
     let(:result) { client.workspaces.reset_sandbox(workspace_id) }

--- a/spec/resources/action_attempt_spec.rb
+++ b/spec/resources/action_attempt_spec.rb
@@ -17,10 +17,11 @@ RSpec.describe Seam::ActionAttempt do
   describe "#wait_until_finished" do
     before do
       stub_seam_request(
-        :get,
-        "/action_attempts/get?action_attempt_id=#{action_attempt_id}",
+        :post,
+        "/action_attempts/get",
         {action_attempt: action_attempt_hash}
-      ).times(2)
+      ).with { |req| req.body.source == {action_attempt_id: action_attempt_id}.to_json }
+        .times(2)
         .then
         .to_return(
           {
@@ -44,10 +45,10 @@ RSpec.describe Seam::ActionAttempt do
     let(:updated_action_attempt_hash) { action_attempt_hash.merge(status: "finished") }
     before do
       stub_seam_request(
-        :get,
-        "/action_attempts/get?action_attempt_id=#{action_attempt_id}",
+        :post,
+        "/action_attempts/get",
         {action_attempt: updated_action_attempt_hash}
-      )
+      ).with { |req| req.body.source == {action_attempt_id: action_attempt_id}.to_json }
     end
 
     it "returns a list of Devices" do


### PR DESCRIPTION
This intention is for GET to be used when possible, but blocking issues mean we need to use POST until we can ensure consistent request serialization and parsing for the query string.