### PR TITLE
Relax http gem version requirement to 5.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     seamapi (1.16.0)
-      http (~> 5.0.0)
+      http (~> 5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/seamapi.gemspec
+++ b/seamapi.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*.rb"]
   spec.files += Dir["[A-Z]*"]
 
-  spec.add_dependency "http", "~> 5.0.0"
+  spec.add_dependency "http", "~> 5.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "gem-release", "~> 2.2"


### PR DESCRIPTION
This will allow installing, e.g. `http 5.1.1` and other 5.x versions. 

Since `http` gem is following semver strictly this should be a safe enough change, but if we want to stay conservative we could also keep increasing the minor version, e.g. `~> 5.1.0`