### PR TITLE
Adds common_code_key attribute to access codes

### DIFF
--- a/lib/seam/clients/access_codes.rb
+++ b/lib/seam/clients/access_codes.rb
@@ -25,14 +25,22 @@ module Seam
         )
       end
 
-      def create(device_id: nil, name: nil, code: nil, starts_at: nil, ends_at: nil, use_backup_access_code_pool: nil, allow_external_modification: nil)
+      def create(device_id: nil, name: nil, code: nil, common_code_key: nil, starts_at: nil, ends_at: nil, use_backup_access_code_pool: nil, allow_external_modification: nil)
         action_attempt = request_seam_object(
           :post,
           "/access_codes/create",
           Seam::ActionAttempt,
           "action_attempt",
-          body: {device_id: device_id, code: code, starts_at: starts_at, ends_at: ends_at, name: name,
-                 use_backup_access_code_pool: use_backup_access_code_pool, allow_external_modification: allow_external_modification}.compact
+          body: {
+            device_id: device_id,
+            code: code,
+            common_code_key: common_code_key,
+            starts_at: starts_at,
+            ends_at: ends_at,
+            name: name,
+            use_backup_access_code_pool: use_backup_access_code_pool,
+            allow_external_modification: allow_external_modification
+          }.compact
         )
         action_attempt.wait_until_finished
         # TODO: check if failed

--- a/lib/seam/resources/access_code.rb
+++ b/lib/seam/resources/access_code.rb
@@ -2,7 +2,7 @@
 
 module Seam
   class AccessCode < BaseResource
-    attr_reader :access_code_id, :name, :type, :code, :is_managed, :status, :device_id, :is_scheduled_on_device, :is_waiting_for_code_assignment, :pulled_backup_access_code_id, :is_backup_access_code_available, :is_backup, :appearance, :is_external_modification_allowed
+    attr_reader :access_code_id, :name, :type, :code, :common_code_key, :is_managed, :status, :device_id, :is_scheduled_on_device, :is_waiting_for_code_assignment, :pulled_backup_access_code_id, :is_backup_access_code_available, :is_backup, :appearance, :is_external_modification_allowed
 
     date_accessor :starts_at, :ends_at, :created_at
 

--- a/spec/clients/access_codes_spec.rb
+++ b/spec/clients/access_codes_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Seam::Clients::AccessCodes do
   end
 
   describe "#create" do
-    let(:access_code_hash) { {device_id: "1234", name: "A C", code: 1234} }
+    let(:access_code_hash) { {device_id: "1234", name: "A C", code: 1234, common_code_key: "abc-123"} }
     let(:action_attempt_hash) { {action_attempt_id: "1234", status: "pending"} }
 
     before do


### PR DESCRIPTION
> Unique identifier for a group of access codes that share the same code.

Note: this field is not available when updating access codes, only when creating.