### PR TITLE
Fix: Syntax in example was incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ _Refer to the [Seam Connect API documentation][Seam Connect API]._
 seam = Seam::Client.new(api_key: "MY_SEAM_API_KEY")
 devices = seam.devices.list
 my_door = devices.first
-seam.locks.unlock(my_door).wait_until_finished
+seam.locks.unlock_door(my_door).wait_until_finished
 ```
 
 ## Development and Testing


### PR DESCRIPTION
The example syntax in README.md was incorrect - it should be `unlock_door`: 

https://github.com/seamapi/ruby/blob/398565cc4c248db5efcc7a899c5a792dab003de9/lib/seam/clients/locks.rb#L10

I came across this while implementing a client in one of our applications. Changing the syntax from `unlock` to `unlock_door` should do the trick!